### PR TITLE
feat: quota fallback model with silent-failure detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to `pi-librarian` are documented here.
 
 ### Added
 
-- None.
+- Quota fallback: when the primary subagent model fails due to quota exhaustion or rate limits, Librarian automatically retries with a fallback model. Two failure modes are handled: exception-based (API throws 429/quota error) and silent failure (model completes with zero tool calls and no output). Fallback model defaults to `anthropic/claude-sonnet-4-6:high` and can be overridden via `PI_LIBRARIAN_FALLBACK_MODEL=provider/model:thinking`. Set to empty string to disable.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,26 @@ export PI_LIBRARIAN_MODEL=google-antigravity/gemini-3-flash:low
 - The requested model must exist in `modelRegistry.getAvailable()` (i.e. credentials are configured for that provider/model).
 - In override mode, selection diagnostics report an explicit `reason` including the chosen `provider/model:thinking`.
 
+## Quota fallback
+
+When the primary subagent model fails due to quota exhaustion or rate limits, Librarian automatically retries with a fallback model. Two failure modes are handled:
+
+- **Exception-based**: API returns a 429 / quota error that throws — detected via error message patterns.
+- **Silent failure**: Model runs but calls no tools and returns no output — detected by inspecting the completed run.
+
+The fallback model defaults to `anthropic/claude-sonnet-4-6:high` and can be overridden:
+
+```bash
+export PI_LIBRARIAN_FALLBACK_MODEL=anthropic/claude-opus-4-6:low
+```
+
+Format is the same as `PI_LIBRARIAN_MODEL`: `provider/model:thinking`.
+
+- Set `PI_LIBRARIAN_FALLBACK_MODEL=""` to disable fallback entirely.
+- The fallback model must be available in `modelRegistry.getAvailable()`.
+- If primary and fallback resolve to the same model ID, fallback is skipped.
+- Selection diagnostics report `fallback (quota): provider/model:thinking` when fallback is active.
+
 ## gh workflow examples (tested)
 
 These are the same patterns encoded in the librarian system prompt.

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -136,6 +136,48 @@ function selectLibrarianSubagentModel(
   };
 }
 
+function isQuotaError(error: unknown): boolean {
+  const msg = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  return (
+    msg.includes("rate limit") ||
+    msg.includes("rate_limit") ||
+    msg.includes("quota") ||
+    msg.includes("429") ||
+    msg.includes("insufficient_quota") ||
+    msg.includes("exceeded your current quota") ||
+    msg.includes("out of credits") ||
+    msg.includes("billing")
+  );
+}
+
+function selectLibrarianFallbackModel(
+  modelRegistry: ExtensionContext["modelRegistry"],
+  primaryModelId: string,
+): LibrarianSubagentModelSelection | null {
+  const rawFallback = (process.env.PI_LIBRARIAN_FALLBACK_MODEL ?? "anthropic/claude-sonnet-4-6:high").trim();
+  if (!rawFallback) return null;
+
+  const parsed = parseLibrarianModelOverride(rawFallback);
+  if ("error" in parsed) return null;
+
+  const provider = parsed.value.provider.toLowerCase();
+  const modelId = parsed.value.modelId.toLowerCase();
+
+  // Don't fall back to the same model we already tried
+  if (modelId === primaryModelId.toLowerCase()) return null;
+
+  const selectedModel = modelRegistry
+    .getAvailable()
+    .find((c) => c.provider.toLowerCase() === provider && c.id.toLowerCase() === modelId);
+  if (!selectedModel) return null;
+
+  return {
+    model: selectedModel,
+    thinkingLevel: parsed.value.thinkingLevel,
+    reason: `fallback (quota): ${selectedModel.provider}/${selectedModel.id}:${parsed.value.thinkingLevel}`,
+  };
+}
+
 function createTurnBudgetExtension(maxTurns: number): ExtensionFactory {
   return (pi) => {
     let turnIndex = 0;
@@ -238,11 +280,12 @@ export default function librarianExtension(pi: ExtensionAPI) {
           };
         }
 
-        const subModel = subModelSelection.model;
-        const subagentThinkingLevel = subModelSelection.thinkingLevel;
-        const subagentSelection = {
+        let subModel = subModelSelection.model;
+        let subagentThinkingLevel = subModelSelection.thinkingLevel;
+        let subagentSelection: SubagentSelectionInfo = {
           reason: subModelSelection.reason,
-        } as const;
+        };
+        const fallbackSelection = selectLibrarianFallbackModel(modelRegistry, subModel.id);
 
         let lastUpdate = 0;
         const emitAll = (force = false) => {
@@ -321,7 +364,27 @@ export default function librarianExtension(pi: ExtensionAPI) {
         let session: any;
         let unsubscribe: (() => void) | undefined;
 
-        try {
+        const looksLikeSilentQuotaFailure = (r: typeof run) =>
+          r.status === "done" && r.toolCalls.length === 0 && (!r.summaryText || r.summaryText === "(no output)");
+
+        const runOneAttempt = async (attemptModel: LibrarianSubagentModel, attemptThinking: ThinkingLevel) => {
+          // Clean up any previous attempt's session before starting a new one
+          if (session) {
+            activeSessions.delete(session as any);
+            unsubscribe?.();
+            session.dispose();
+            session = undefined;
+            unsubscribe = undefined;
+          }
+
+          run.status = "running";
+          run.turns = 0;
+          run.toolCalls = [];
+          run.startedAt = Date.now();
+          run.endedAt = undefined;
+          run.error = undefined;
+          run.summaryText = undefined;
+
           const resourceLoader = new DefaultResourceLoader({
             noExtensions: true,
             additionalExtensionPaths: ["npm:pi-subdir-context"],
@@ -334,21 +397,13 @@ export default function librarianExtension(pi: ExtensionAPI) {
           });
           await resourceLoader.reload();
 
-          run.status = "running";
-          run.turns = 0;
-          run.toolCalls = [];
-          run.startedAt = Date.now();
-          run.endedAt = undefined;
-          run.error = undefined;
-          run.summaryText = undefined;
-
           const { session: createdSession } = await createAgentSession({
             cwd: workspace,
             modelRegistry,
             resourceLoader,
             sessionManager: SessionManager.inMemory(workspace),
-            model: subModel,
-            thinkingLevel: subagentThinkingLevel,
+            model: attemptModel,
+            thinkingLevel: attemptThinking,
             tools: [createReadTool(workspace), createBashTool(workspace)],
           });
 
@@ -395,6 +450,31 @@ export default function librarianExtension(pi: ExtensionAPI) {
           run.status = wasAborted() ? "aborted" : "done";
           run.endedAt = Date.now();
           emitAll(true);
+        };
+
+        try {
+          try {
+            await runOneAttempt(subModel, subagentThinkingLevel);
+            // Detect silent quota exhaustion: model ran, made no tool calls, returned nothing
+            if (!wasAborted() && fallbackSelection && looksLikeSilentQuotaFailure(run)) {
+              subModel = fallbackSelection.model;
+              subagentThinkingLevel = fallbackSelection.thinkingLevel;
+              subagentSelection = { reason: `${fallbackSelection.reason} (silent quota)` };
+              emitAll(true);
+              await runOneAttempt(subModel, subagentThinkingLevel);
+            }
+          } catch (primaryError) {
+            if (!wasAborted() && fallbackSelection && isQuotaError(primaryError)) {
+              // Switch to fallback model and retry
+              subModel = fallbackSelection.model;
+              subagentThinkingLevel = fallbackSelection.thinkingLevel;
+              subagentSelection = { reason: fallbackSelection.reason };
+              emitAll(true);
+              await runOneAttempt(subModel, subagentThinkingLevel);
+            } else {
+              throw primaryError;
+            }
+          }
         } catch (error) {
           const message = wasAborted() ? "Aborted" : error instanceof Error ? error.message : String(error);
           run.status = wasAborted() ? "aborted" : "error";


### PR DESCRIPTION
## Summary

Port of the same quota fallback logic from [pi-finder PR #2](https://github.com/default-anton/pi-finder/pull/2) — the two packages share the same session structure so the change is identical in shape.

## Problem

When the primary subagent model hits quota exhaustion or rate limits, Librarian fails silently or throws. Two failure modes observed:
- **Exception-based**: API throws a 429/quota error
- **Silent failure**: model completes `status: done` but made **zero tool calls** and returned no output — the pattern seen with weekly quota exhaustion on Codex models

## Changes

### `extensions/index.ts`

- Added `isQuotaError(error)`: detects quota/rate-limit exceptions via error message patterns
- Added `selectLibrarianFallbackModel(modelRegistry, primaryModelId)`: reads `PI_LIBRARIAN_FALLBACK_MODEL` env var (defaults to `anthropic/claude-sonnet-4-6:high`), skips if same model as primary
- Added `looksLikeSilentQuotaFailure(run)`: detects silent failure — `status === done`, zero tool calls, no output
- Extracted `runOneAttempt(model, thinkingLevel)`: encapsulates session lifecycle with cleanup on retry
- Retry logic: on exception → check `isQuotaError`; on success → check `looksLikeSilentQuotaFailure`; if either triggers and fallback is available, switch model and re-run

### `README.md`

Added **Quota fallback** section documenting both failure modes, `PI_LIBRARIAN_FALLBACK_MODEL` override, and selection diagnostics format.

### `CHANGELOG.md`

Added entry under `[Unreleased]`.

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `PI_LIBRARIAN_FALLBACK_MODEL` | `anthropic/claude-sonnet-4-6:high` | Fallback model when primary quota exhausted |

Set to empty string (`PI_LIBRARIAN_FALLBACK_MODEL=""`) to disable fallback entirely.